### PR TITLE
Added ADF test

### DIFF
--- a/Volume_(Currency)_time_series.ipynb
+++ b/Volume_(Currency)_time_series.ipynb
@@ -6,7 +6,7 @@
       "name": "Volume_(Currency)_time_series.ipynb",
       "provenance": [],
       "collapsed_sections": [],
-      "authorship_tag": "ABX9TyOKjNr/VQrxOUxK0+Fd7k7f",
+      "authorship_tag": "ABX9TyMOSR5bxPJsPMfrYqONYuvh",
       "include_colab_link": true
     },
     "kernelspec": {
@@ -3295,7 +3295,7 @@
         "id": "VC4Wm3lemDno"
       },
       "source": [
-        "####Looks like this doesn't have any trend but the seasonality is hard to tell"
+        "####Looks like this doesn't have any trend but the seasonality is hard to tell. It may be because the datapoints are too much so it makes it harder to visualize."
       ]
     },
     {
@@ -3564,9 +3564,357 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dOQqgFZIyHe6"
+      },
+      "source": [
+        "###For the daily downsampled 'bitcoin_df_imputation1' dataset"
+      ]
+    },
+    {
       "cell_type": "code",
       "metadata": {
-        "id": "HIoV8clFoM3m"
+        "id": "HIoV8clFoM3m",
+        "outputId": "e98ddc78-6f28-4e0d-caf8-0193bec81f81",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 156
+        }
+      },
+      "source": [
+        "# ADF TEST\n",
+        "from statsmodels.tsa.stattools import adfuller \n",
+        "adf_result = adfuller(bitcoin_df_imputation1_daily['Volume_(Currency)'])\n",
+        "print(f'ADF Statistic: {adf_result[0]}')\n",
+        "print(f'p_value: {adf_result[1]}')\n",
+        "print(f'No. of lags used: {adf_result[2]}')\n",
+        "print(f'No. of observations used: {adf_result[3]}')\n",
+        "print(f'Critical_values:')\n",
+        "for k, v in adf_result[4].items():\n",
+        "  print(f'  {k} : {v}')"
+      ],
+      "execution_count": 78,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "ADF Statistic: -3.0189192426131735\n",
+            "p_value: 0.03316495860260986\n",
+            "No. of lags used: 27\n",
+            "No. of observations used: 3153\n",
+            "Critical_values:\n",
+            "  1% : -3.4324256840496985\n",
+            "  5% : -2.8624571096973295\n",
+            "  10% : -2.5672581988257397\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Sdy4UUUp8U2K"
+      },
+      "source": [
+        "####The results above show the data is **stationary** because although the p-value is greater than the 5% critical value, the ADF statistic is less than the 5% critical value"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_fght-HO2j1o"
+      },
+      "source": [
+        "###For the daily downsampled 'bitcoin_df_imputation2' dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "qwYR1jLi0dWV",
+        "outputId": "b7bd9f9c-db96-4af1-c95a-881ca5a906ee",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 156
+        }
+      },
+      "source": [
+        "adf_result = adfuller(bitcoin_df_imputation2_daily['Volume_(Currency)'])\n",
+        "print(f'ADF Statistic: {adf_result[0]}')\n",
+        "print(f'p_value: {adf_result[1]}')\n",
+        "print(f'No. of lags used: {adf_result[2]}')\n",
+        "print(f'No. of observations used: {adf_result[3]}')\n",
+        "print(f'Critical_values:')\n",
+        "for k, v in adf_result[4].items():\n",
+        "  print(f'  {k} : {v}')"
+      ],
+      "execution_count": 79,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "ADF Statistic: -3.0189192426131735\n",
+            "p_value: 0.03316495860260986\n",
+            "No. of lags used: 27\n",
+            "No. of observations used: 3153\n",
+            "Critical_values:\n",
+            "  1% : -3.4324256840496985\n",
+            "  5% : -2.8624571096973295\n",
+            "  10% : -2.5672581988257397\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3imdTUG9Gkve"
+      },
+      "source": [
+        "####The results above show the data is **stationary** because although the p-value is greater than the 5% critical value, the ADF statistic is less than the 5% critical value"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JpbJ7OpmUZme"
+      },
+      "source": [
+        "###For the weekly downsampled 'bitcoin_df_imputation1' dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "KKGH56hu28KL",
+        "outputId": "2b8faa1b-86de-45e6-d221-a1015f724d8e",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 156
+        }
+      },
+      "source": [
+        "adf_result = adfuller(bitcoin_df_imputation1_weekly['Volume_(Currency)'])\n",
+        "print(f'ADF Statistic: {adf_result[0]}')\n",
+        "print(f'p_value: {adf_result[1]}')\n",
+        "print(f'No. of lags used: {adf_result[2]}')\n",
+        "print(f'No. of observations used: {adf_result[3]}')\n",
+        "print(f'Critical_values:')\n",
+        "for k, v in adf_result[4].items():\n",
+        "  print(f'  {k} : {v}')"
+      ],
+      "execution_count": 80,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "ADF Statistic: -2.6086978821118167\n",
+            "p_value: 0.09121288426014085\n",
+            "No. of lags used: 15\n",
+            "No. of observations used: 440\n",
+            "Critical_values:\n",
+            "  1% : -3.445299682487321\n",
+            "  5% : -2.8681312035123967\n",
+            "  10% : -2.570280872933884\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "szczuLRmHYOt"
+      },
+      "source": [
+        "####The results above show the data is **non-stationary** because both the p-value and the ADF statistic is greater than the 5% critical value"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dxsdh2cKUhvw"
+      },
+      "source": [
+        "###For the weekly downsampled 'bitcoin_df_imputation2' dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "_aTD6q71_6S1",
+        "outputId": "dc77bcaa-66b7-4840-9831-4035184602c1",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 156
+        }
+      },
+      "source": [
+        "adf_result = adfuller(bitcoin_df_imputation2_weekly['Volume_(Currency)'])\n",
+        "print(f'ADF Statistic: {adf_result[0]}')\n",
+        "print(f'p_value: {adf_result[1]}')\n",
+        "print(f'No. of lags used: {adf_result[2]}')\n",
+        "print(f'No. of observations used: {adf_result[3]}')\n",
+        "print(f'Critical_values:')\n",
+        "for k, v in adf_result[4].items():\n",
+        "  print(f'  {k} : {v}')"
+      ],
+      "execution_count": 81,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "ADF Statistic: -2.6086978821118167\n",
+            "p_value: 0.09121288426014085\n",
+            "No. of lags used: 15\n",
+            "No. of observations used: 440\n",
+            "Critical_values:\n",
+            "  1% : -3.445299682487321\n",
+            "  5% : -2.8681312035123967\n",
+            "  10% : -2.570280872933884\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xMTEGc1xHson"
+      },
+      "source": [
+        "####The results above show the data is **non-stationary** because both the p-value and the ADF statistic is greater than the 5% critical value"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "RgvJHbKHUoz-"
+      },
+      "source": [
+        "###For the monthly downsampled 'bitcoin_df_imputation1' dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "7OtiNwqYAS23",
+        "outputId": "e35e50bc-8eec-40fb-b97b-bfd091523eb5",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 156
+        }
+      },
+      "source": [
+        "adf_result = adfuller(bitcoin_df_imputation1_monthly['Volume_(Currency)'])\n",
+        "print(f'ADF Statistic: {adf_result[0]}')\n",
+        "print(f'p_value: {adf_result[1]}')\n",
+        "print(f'No. of lags used: {adf_result[2]}')\n",
+        "print(f'No. of observations used: {adf_result[3]}')\n",
+        "print(f'Critical_values:')\n",
+        "for k, v in adf_result[4].items():\n",
+        "  print(f'  {k} : {v}')"
+      ],
+      "execution_count": 83,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "ADF Statistic: -2.6237506665006576\n",
+            "p_value: 0.08818716513754626\n",
+            "No. of lags used: 0\n",
+            "No. of observations used: 105\n",
+            "Critical_values:\n",
+            "  1% : -3.4942202045135513\n",
+            "  5% : -2.889485291005291\n",
+            "  10% : -2.5816762131519275\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8MuGrQiRUyGP"
+      },
+      "source": [
+        "####The results above show the data is **non-stationary** because both the p-value and the ADF statistic is greater than the 5% critical value"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Wyrt2ZkwUu6Z"
+      },
+      "source": [
+        "###For the monthly downsampled 'bitcoin_df_imputation2' dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "8aTvdaxPH0wZ",
+        "outputId": "3692d5ee-78f9-4cbc-ac1d-9ae73ef1c2bc",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 156
+        }
+      },
+      "source": [
+        "adf_result = adfuller(bitcoin_df_imputation2_monthly['Volume_(Currency)'])\n",
+        "print(f'ADF Statistic: {adf_result[0]}')\n",
+        "print(f'p_value: {adf_result[1]}')\n",
+        "print(f'No. of lags used: {adf_result[2]}')\n",
+        "print(f'No. of observations used: {adf_result[3]}')\n",
+        "print(f'Critical_values:')\n",
+        "for k, v in adf_result[4].items():\n",
+        "  print(f'  {k} : {v}')"
+      ],
+      "execution_count": 84,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "ADF Statistic: -2.6237506665006576\n",
+            "p_value: 0.08818716513754626\n",
+            "No. of lags used: 0\n",
+            "No. of observations used: 105\n",
+            "Critical_values:\n",
+            "  1% : -3.4942202045135513\n",
+            "  5% : -2.889485291005291\n",
+            "  10% : -2.5816762131519275\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TV1XsQIRVSem"
+      },
+      "source": [
+        "###The results above show the data is **non-stationary** because both the p-value and the ADF statistic is greater than the 5% critical value"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ultkEFb-WNdn"
+      },
+      "source": [
+        "**From all the results obtained, The series was stationary only for the daily sampled dataset and non-stationary for the weekly and monthly datasets.\n",
+        "As a result, the weekly and monthly timeframe datasets have to be made stationary.**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "-OECz9XyXKDu"
       },
       "source": [
         ""


### PR DESCRIPTION
ADF Test was done on the 'Volume_(Currency)' column series. The series from the daily downsampling was confirmed to be stationary while the series from the weekly and monthly downsampling were confirmed to be non-stationary.

The notebook link is [here](https://github.com/FiyinfobaO/05-bitcoin-trading/blob/master/Volume_(Currency)_time_series.ipynb)

The card is [here](https://github.com/HamoyeHQ/05-bitcoin-trading/projects/2#card-46550174)